### PR TITLE
Implement Frame and FrameObject classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 *~
+
+[Cc][Mm]ake*
+!CMakeLists.txt
+
+Makefile
+
+bin/*
+lib/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ include_directories(cpp/include)
 include_directories(${Boost_INCLUDE_DIRS})
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+add_library(frame SHARED cpp/src/frame.cpp)
+target_link_libraries(frame pthread ${Boost_LIBRARIES})
+
 add_library(photon_propagator SHARED cpp/src/photon_propagator.cpp)
 target_link_libraries(photon_propagator pthread ${Boost_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,11 @@ include_directories(cpp/include)
 include_directories(${Boost_INCLUDE_DIRS})
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-
 add_library(frame SHARED cpp/src/frame.cpp)
-target_link_libraries(frame pthread ${Boost_LIBRARIES})
-
 add_library(photon_propagator SHARED cpp/src/photon_propagator.cpp)
 target_link_libraries(photon_propagator pthread ${Boost_LIBRARIES})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 add_executable(run cpp/src/run.cpp)
 target_link_libraries(run pthread ${Boost_LIBRARIES})
-
 

--- a/cpp/include/frame.hpp
+++ b/cpp/include/frame.hpp
@@ -3,12 +3,11 @@
  */
 #pragma once
 
+#include <iostream>
 #include <string>
 #include <map>
 #include <memory>
 #include <vector>
-
-#include <iostream>
 
 
 class FrameObject {
@@ -19,11 +18,7 @@ class FrameObject {
     const std::string get_pretty_name() const { return pretty_name_; }
 };
 
-std::ostream& operator<<(std::ostream& os, const FrameObject& fo)
-{
-  return os << fo.get_pretty_name();
-}
-
+std::ostream& operator<<(std::ostream& os, const FrameObject& fo);
 
 
 class Frame {
@@ -74,13 +69,4 @@ class Frame {
 
 };
 
-std::ostream& operator<<(std::ostream& os, const Frame& f)
-{
-  os << "Frame:";
-  for (const std::string& key : f.keys())
-  {
-    auto obj = f.get(key);
-    os << "\n\t" << key << ":\t" << *obj << " (" << obj << ")";
-  }
-  return os;
-}
+std::ostream& operator<<(std::ostream& os, const Frame& f);

--- a/cpp/include/frame.hpp
+++ b/cpp/include/frame.hpp
@@ -3,6 +3,84 @@
  */
 #pragma once
 
+#include <string>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <iostream>
+
+
+class FrameObject {
+  protected:
+    std::string pretty_name_ = "Default Frame Object";
+
+  public:
+    const std::string get_pretty_name() const { return pretty_name_; }
+};
+
+std::ostream& operator<<(std::ostream& os, const FrameObject& fo)
+{
+  return os << fo.get_pretty_name();
+}
+
+
+
 class Frame {
+  private:
+    std::map<std::string, std::shared_ptr<FrameObject> > object_map_;
+
+  public:
+    // Constructor
+    Frame() = default;
+    // Destructor
+    ~Frame() = default;
+    // Copy Constructor
+    Frame(const Frame&) = default;
+    // Move Constructor
+    Frame(Frame&&) = default;
+    // Copy Assignment
+    Frame& operator=(const Frame&) = default;
+    // Move Assignment
+    Frame& operator=(Frame&&) = default;
+
+    void add(const std::string& key, std::shared_ptr<FrameObject> object_ptr)
+    {
+      std::cout << "Adding " << key << "...";
+      if (object_map_[key]==nullptr) {object_map_[key] = object_ptr;}
+      else {std::cout << " FAILED";} // Raise an error here?
+      std::cout << std::endl;
+    }
+
+    std::shared_ptr<FrameObject> get(const std::string& key) const
+    {
+      auto iter = object_map_.find(key);
+      if (iter!=object_map_.end()) { return iter->second; }
+      else { return nullptr; }
+    }
+
+    void remove(const std::string& key)
+    { std::cout << "Removing " << key << std::endl; object_map_[key] = nullptr; }
+
+    const std::vector<std::string> keys() const
+    {
+      std::vector<std::string> keys;
+      for (auto const& map_pair : object_map_)
+      {
+        if (map_pair.second!=nullptr) { keys.push_back(map_pair.first); }
+      }
+      return keys;
+    }
 
 };
+
+std::ostream& operator<<(std::ostream& os, const Frame& f)
+{
+  os << "Frame:";
+  for (const std::string& key : f.keys())
+  {
+    auto obj = f.get(key);
+    os << "\n\t" << key << ":\t" << *obj << " (" << obj << ")";
+  }
+  return os;
+}

--- a/cpp/include/frame.hpp
+++ b/cpp/include/frame.hpp
@@ -39,33 +39,15 @@ class Frame {
     // Move Assignment
     Frame& operator=(Frame&&) = default;
 
-    void add(const std::string& key, std::shared_ptr<FrameObject> object_ptr)
-    {
-      std::cout << "Adding " << key << "...";
-      if (object_map_[key]==nullptr) {object_map_[key] = object_ptr;}
-      else {std::cout << " FAILED";} // Raise an error here?
-      std::cout << std::endl;
-    }
+    void add(const std::string& key, std::shared_ptr<FrameObject> object_ptr);
 
-    std::shared_ptr<FrameObject> get(const std::string& key) const
-    {
-      auto iter = object_map_.find(key);
-      if (iter!=object_map_.end()) { return iter->second; }
-      else { return nullptr; }
-    }
+    std::shared_ptr<FrameObject> get(const std::string& key) const;
 
-    void remove(const std::string& key)
-    { std::cout << "Removing " << key << std::endl; object_map_[key] = nullptr; }
+    void remove(const std::string& key);
 
-    const std::vector<std::string> keys() const
-    {
-      std::vector<std::string> keys;
-      for (auto const& map_pair : object_map_)
-      {
-        if (map_pair.second!=nullptr) { keys.push_back(map_pair.first); }
-      }
-      return keys;
-    }
+    const std::vector<std::string> keys() const;
+
+    const bool empty() const;
 
 };
 

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -7,9 +7,53 @@ std::ostream& operator<<(std::ostream& os, const FrameObject& fo)
 }
 
 
+
+
+void Frame::add(const std::string& key, std::shared_ptr<FrameObject> object_ptr)
+{
+  if (object_map_[key]==nullptr) {object_map_[key] = object_ptr;}
+  else {} // Raise an error here?
+}
+
+std::shared_ptr<FrameObject> Frame::get(const std::string& key) const
+{
+  auto iter = object_map_.find(key);
+  if (iter!=object_map_.end()) { return iter->second; }
+  else { return nullptr; }
+}
+
+void Frame::remove(const std::string& key)
+{
+  object_map_[key] = nullptr;
+}
+
+const std::vector<std::string> Frame::keys() const
+{
+  std::vector<std::string> keys;
+  for (auto const& map_pair : object_map_)
+  {
+    if (map_pair.second!=nullptr) { keys.push_back(map_pair.first); }
+  }
+  return keys;
+}
+
+const bool Frame::empty() const
+{
+  for (auto const& map_pair : object_map_)
+  {
+    if (map_pair.second!=nullptr) {return false;}
+  }
+  return true;
+}
+
+
 std::ostream& operator<<(std::ostream& os, const Frame& f)
 {
   os << "Frame:";
+  if (f.empty())
+  {
+    return os << "\n\tFrame is empty";
+  }
   for (const std::string& key : f.keys())
   {
     auto obj = f.get(key);

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -1,0 +1,19 @@
+#include "frame.hpp"
+
+
+std::ostream& operator<<(std::ostream& os, const FrameObject& fo)
+{
+  return os << fo.get_pretty_name();
+}
+
+
+std::ostream& operator<<(std::ostream& os, const Frame& f)
+{
+  os << "Frame:";
+  for (const std::string& key : f.keys())
+  {
+    auto obj = f.get(key);
+    os << "\n\t" << key << ":\t" << *obj << " (" << obj << ")";
+  }
+  return os;
+}

--- a/cpp/src/run.cpp
+++ b/cpp/src/run.cpp
@@ -3,9 +3,6 @@
 #include <photon_propagator.hpp>
 #include <tray.hpp>
 
-#include <frame.hpp>
-#include <iostream>
-
 using std::string;
 
 int main(int argc, char** argv){
@@ -22,10 +19,6 @@ int main(int argc, char** argv){
   t.add(reader);
   t.add(propagator);
   t.add(writer);
-  t.execute();  
-
-  std::shared_ptr<FrameObject> obj(new FrameObject);
-  Frame frame;
-  std::cout << frame << std::endl;
+  t.execute();
 }
  

--- a/cpp/src/run.cpp
+++ b/cpp/src/run.cpp
@@ -3,6 +3,9 @@
 #include <photon_propagator.hpp>
 #include <tray.hpp>
 
+#include <frame.hpp>
+#include <iostream>
+
 using std::string;
 
 int main(int argc, char** argv){
@@ -20,5 +23,9 @@ int main(int argc, char** argv){
   t.add(propagator);
   t.add(writer);
   t.execute();  
+
+  std::shared_ptr<FrameObject> obj(new FrameObject);
+  Frame frame;
+  std::cout << frame << std::endl;
 }
  


### PR DESCRIPTION
Frame handles a map of strings to FrameObject shared pointers. Implements add, get, remove, and keys functions which do what you would expect to the frame. FrameObject is a nearly empty base class for particles, etc. The only thing to extend in child classes is pretty_name_, which is just what is used to distinguish what the class is without relying on the class name in the code.